### PR TITLE
feat: add extendInjectedScript public API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright-repl/playwright-crx",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright-repl/playwright-crx",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "Apache-2.0",
       "workspaces": [
         "examples/recorder-crx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/playwright-crx",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "engines": {
     "node": ">=18"
   },

--- a/src/client/crx.ts
+++ b/src/client/crx.ts
@@ -182,6 +182,10 @@ export class CrxApplication extends ChannelOwner<channels.CrxApplicationChannel>
     return from<Page>((await this._channel.newPage(options ?? {})).page);
   }
 
+  async extendInjectedScript(source: string, arg?: any): Promise<void> {
+    await this._channel.extendInjectedScript({ source, arg });
+  }
+
   async close() {
     await this._channel.close();
   }

--- a/src/protocol/channels.ts
+++ b/src/protocol/channels.ts
@@ -78,6 +78,7 @@ export interface CrxApplicationChannel extends CrxApplicationEventTarget, Channe
   list(params?: CrxApplicationListParams, metadata?: CallMetadata): Promise<CrxApplicationListResult>;
   load(params?: CrxApplicationLoadParams, metadata?: CallMetadata): Promise<CrxApplicationLoadResult>;
   run(params?: CrxApplicationRunParams, metadata?: CallMetadata): Promise<CrxApplicationRunResult>;
+  extendInjectedScript(params: CrxApplicationExtendInjectedScriptParams, metadata?: CallMetadata): Promise<CrxApplicationExtendInjectedScriptResult>;
 }
 export type CrxApplicationHideEvent = {};
 export type CrxApplicationShowEvent = {};
@@ -228,6 +229,9 @@ export type CrxApplicationLoadResult = void;
 export type CrxApplicationRunParams = { page?: PageChannel, code: string };
 export type CrxApplicationRunOptions = { page?: PageChannel, code: string};
 export type CrxApplicationRunResult = void;
+export type CrxApplicationExtendInjectedScriptParams = { source: string, arg?: any };
+export type CrxApplicationExtendInjectedScriptOptions = { source: string, arg?: any };
+export type CrxApplicationExtendInjectedScriptResult = void;
 
 export interface CrxApplicationEvents {
   'hide': CrxApplicationHideEvent;

--- a/src/protocol/validator.ts
+++ b/src/protocol/validator.ts
@@ -169,3 +169,8 @@ scheme.CrxApplicationRunParams = tObject({
   code: tString,
 });
 scheme.CrxApplicationRunResult = tOptional(tObject({}));
+scheme.CrxApplicationExtendInjectedScriptParams = tObject({
+  source: tString,
+  arg: tOptional(tString),
+});
+scheme.CrxApplicationExtendInjectedScriptResult = tOptional(tObject({}));

--- a/src/server/crx.ts
+++ b/src/server/crx.ts
@@ -263,6 +263,10 @@ export class CrxApplication extends SdkObject {
     this._recorderApp?._recorder.setMode(mode);
   }
 
+  async extendInjectedScript(source: string, arg?: any) {
+    await this._context.extendInjectedScript(source, arg);
+  }
+
   async attach(tabId: number): Promise<Page> {
     const { targetId, browserContextId } = await this._transport.attach(tabId);
     const tab = await chrome.tabs.get(tabId);

--- a/src/server/dispatchers/crxDispatcher.ts
+++ b/src/server/dispatchers/crxDispatcher.ts
@@ -114,4 +114,8 @@ export class CrxApplicationDispatcher extends Dispatcher<CrxApplication, channel
   async run(params: channels.CrxApplicationRunParams): Promise<void> {
     await this._object.run(params.code, (params.page as PageDispatcher)?._object);
   }
+
+  async extendInjectedScript(params: channels.CrxApplicationExtendInjectedScriptParams): Promise<void> {
+    await this._object.extendInjectedScript(params.source, params.arg);
+  }
 }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -293,6 +293,18 @@ export interface CrxApplication {
   context(): BrowserContext;
 
   /**
+   * Injects custom code into the utility world alongside InjectedScript.
+   * The source must export a default function that returns a constructor.
+   * The constructor receives (injectedScript, arg) parameters, giving
+   * synchronous access to Playwright's selector generation, ARIA APIs, etc.
+   * Auto-installs on new pages and navigations.
+   *
+   * @param source JavaScript source code in module format.
+   * @param arg Optional argument passed to the constructor.
+   */
+  extendInjectedScript(source: string, arg?: any): Promise<void>;
+
+  /**
    * @param tabIdOrPage
    */
   detach(tabIdOrPage: number|Page): Promise<void>;


### PR DESCRIPTION
## Summary

- Exposes `BrowserContext.extendInjectedScript` through the full dispatcher chain (channels → validator → server → dispatcher → client → types)
- Enables extensions to inject custom code into the utility world alongside Playwright's `InjectedScript`
- Gives synchronous access to `generateSelectorSimple()`, `asLocator()`, and other internal APIs
- Auto-installs on new pages and navigations

## Test plan

- [x] Manually tested end-to-end with playwright-repl extension
- [x] Verified injection works: `generateSelectorSimple()` + `asLocator()` produce Playwright-quality locators
- [x] Verified auto-install on navigation
- [x] `build:crx` passes (pre-existing tsc errors in test types unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)