### PR TITLE
fix: mark CrxApplication attach/detach as internal in trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.21.2
+
+### Bug Fixes
+
+- **Mark CrxApplication attach/detach as internal** — `attach`, `attachAll`, `detach`, and `detachAll` methods are now marked as `internal` in protocol metainfo, preventing them from appearing as failed actions in the Playwright Trace Viewer.
+
 ## 1.21.1
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@playwright-repl/playwright-crx",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@playwright-repl/playwright-crx",
-      "version": "1.21.1",
+      "version": "1.21.2",
       "license": "Apache-2.0",
       "workspaces": [
         "examples/todomvc-crx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playwright-repl/playwright-crx",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "engines": {
     "node": ">=18"
   },

--- a/playwright/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
+++ b/playwright/packages/playwright-core/src/utils/isomorphic/protocolMetainfo.ts
@@ -335,7 +335,11 @@ export const methodMetainfo = new Map<string, MethodMetainfo>([
   ['AndroidDevice.connectToWebView', { title: 'Connect to Web View', }],
   ['AndroidDevice.close', { internal: true, }],
   ['JsonPipe.send', { internal: true, }],
-  ['JsonPipe.close', { internal: true, }]
+  ['JsonPipe.close', { internal: true, }],
+  ['CrxApplication.attach', { internal: true, }],
+  ['CrxApplication.attachAll', { internal: true, }],
+  ['CrxApplication.detach', { internal: true, }],
+  ['CrxApplication.detachAll', { internal: true, }],
 ]);
 
 export function getMetainfo(metadata: { type: string, method: string }): MethodMetainfo | undefined {


### PR DESCRIPTION
## Summary
- Mark `CrxApplication.attach`, `attachAll`, `detach`, and `detachAll` as `internal: true` in `protocolMetainfo.ts`
- These internal operations no longer appear as failed actions in the Playwright Trace Viewer
- Bump version to 1.21.2

## Before
Trace Viewer showed multiple red failed `CrxApplication.attach` entries with "Frame has been detached" errors and `about:blank` navigations — confusing to users.

## After
Only user actions (goto, click, etc.) appear in the trace.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)